### PR TITLE
feat: invalidate web-server OPcache from WP-CLI via REST endpoint

### DIFF
--- a/includes/src/CliOpcache.php
+++ b/includes/src/CliOpcache.php
@@ -82,16 +82,6 @@ final class CliOpcache
     }
 
     /**
-     * Initialize hooks (web-server process only).
-     *
-     * @return void
-     */
-    public function init()
-    {
-        add_action('rest_api_init', [$this, 'register_rest_route']);
-    }
-
-    /**
      * Register the REST endpoint.
      *
      * @return void

--- a/includes/src/CliOpcache.php
+++ b/includes/src/CliOpcache.php
@@ -59,14 +59,6 @@ final class CliOpcache
     const SECRET_KEY = 'cli_opcache_secret';
 
     /**
-     * Whether a bulk (full) flush is in progress.
-     * Used to suppress per-file notifications during cachedir_flush().
-     *
-     * @var bool
-     */
-    private static $bulk_flush = false;
-
-    /**
      * Plugin instance.
      *
      * @var Plugin
@@ -175,32 +167,14 @@ final class CliOpcache
     }
 
     /**
-     * Signal that a bulk flush is starting or ending.
-     * While true, per-file notifications in unlink() are suppressed.
-     *
-     * @param bool $state
-     * @return void
-     */
-    public static function set_bulk_flush(bool $state)
-    {
-        self::$bulk_flush = $state;
-    }
-
-    /**
-     * Whether a bulk flush is currently in progress.
-     *
-     * @return bool
-     */
-    public static function is_bulk_flush(): bool
-    {
-        return self::$bulk_flush;
-    }
-
-    /**
-     * Called from WP-CLI after cache files are flushed.
+     * Called from WP-CLI after cache files are explicitly flushed.
      *
      * Fires a non-blocking HTTP POST to the REST endpoint so that
      * opcache_invalidate() / opcache_reset() runs in the web-server process.
+     *
+     * Only fires during explicit flush operations (cachedir_flush or a
+     * deliberate wp_cache_delete call), never during normal cache eviction
+     * that happens as a side-effect of cache reads.
      *
      * @param array $files  Absolute paths of cache files that were flushed.
      *                      Pass an empty array to request a full opcache_reset().
@@ -231,7 +205,11 @@ final class CliOpcache
         $timestamp = (string) time();
         $signature = \hash_hmac('sha256', $timestamp.$body, $secret);
 
-        $url = \get_rest_url(null, self::REST_NAMESPACE.self::REST_ROUTE);
+        // Build the REST URL without get_rest_url() which requires $wp_rewrite
+        // to be initialised (only available after the 'init' action). We use
+        // home_url() which is safe to call at any point after plugins_loaded.
+        $rest_prefix = \defined('REST_API_PREFIX') ? \REST_API_PREFIX : 'wp-json';
+        $url = \trailingslashit(\get_option('siteurl')).$rest_prefix.'/'.self::REST_NAMESPACE.self::REST_ROUTE;
 
         \wp_remote_post(
             $url,

--- a/includes/src/CliOpcache.php
+++ b/includes/src/CliOpcache.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Docket Cache.
+ *
+ * @author  Nawawi Jamili
+ * @license MIT
+ *
+ * @see    https://github.com/nawawi/docket-cache
+ */
+
+namespace Nawawi\DocketCache;
+
+\defined('ABSPATH') || exit;
+
+/**
+ * CliOpcache.
+ *
+ * Bridges WP-CLI cache operations to the web-server OPcache.
+ *
+ * Problem: when opcache.validate_timestamps=0 (common on production for
+ * performance), truncating or deleting a Docket Cache PHP file from the CLI
+ * has no effect on the web server's in-memory OPcache because:
+ *   1. opcache.enable_cli=0 by default, so opcache_invalidate() from CLI
+ *      operates on a separate (disabled) OPcache segment.
+ *   2. With validate_timestamps=0 the web server never re-checks file mtimes.
+ *
+ * Solution: when running under WP-CLI, after flushing cache files, fire a
+ * non-blocking HTTP POST to a REST endpoint registered by this plugin. That
+ * request runs inside the web-server process where opcache_invalidate() /
+ * opcache_reset() actually work.
+ *
+ * Security: a shared secret (HMAC-SHA256) is auto-generated on first use and
+ * stored in the Docket Cache data directory (web-server-owned). The CLI reads
+ * the same file. No user configuration required.
+ *
+ * Opt-out: define('DOCKET_CACHE_WPCLI_OPCACHE', false) in wp-config.php.
+ */
+final class CliOpcache
+{
+    /**
+     * REST namespace.
+     *
+     * @var string
+     */
+    const REST_NAMESPACE = 'docket-cache/v1';
+
+    /**
+     * REST route.
+     *
+     * @var string
+     */
+    const REST_ROUTE = '/opcache-invalidate';
+
+    /**
+     * Secret lookup key used with Canopt::lookup_set/get.
+     *
+     * @var string
+     */
+    const SECRET_KEY = 'cli_opcache_secret';
+
+    /**
+     * Whether a bulk (full) flush is in progress.
+     * Used to suppress per-file notifications during cachedir_flush().
+     *
+     * @var bool
+     */
+    private static $bulk_flush = false;
+
+    /**
+     * Plugin instance.
+     *
+     * @var Plugin
+     */
+    private $pt;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(Plugin $pt)
+    {
+        $this->pt = $pt;
+    }
+
+    /**
+     * Initialize hooks (web-server process only).
+     *
+     * @return void
+     */
+    public function init()
+    {
+        add_action('rest_api_init', [$this, 'register_rest_route']);
+    }
+
+    /**
+     * Register the REST endpoint.
+     *
+     * @return void
+     */
+    public function register_rest_route()
+    {
+        register_rest_route(
+            self::REST_NAMESPACE,
+            self::REST_ROUTE,
+            [
+                'methods'             => 'POST',
+                'callback'            => [$this, 'handle_request'],
+                'permission_callback' => [$this, 'verify_request'],
+            ]
+        );
+    }
+
+    /**
+     * Verify the HMAC signature on incoming requests.
+     *
+     * @param \WP_REST_Request $request
+     * @return bool|\WP_Error
+     */
+    public function verify_request(\WP_REST_Request $request)
+    {
+        $signature = $request->get_header('X-Docket-Signature');
+        $timestamp  = $request->get_header('X-Docket-Timestamp');
+
+        if (empty($signature) || empty($timestamp)) {
+            return new \WP_Error('missing_headers', 'Missing authentication headers.', ['status' => 401]);
+        }
+
+        // Reject requests older than 30 seconds to prevent replay attacks.
+        if (\abs(time() - (int) $timestamp) > 30) {
+            return new \WP_Error('expired_request', 'Request timestamp expired.', ['status' => 401]);
+        }
+
+        $secret = $this->get_or_create_secret();
+        if (empty($secret)) {
+            return new \WP_Error('no_secret', 'Shared secret not available.', ['status' => 500]);
+        }
+
+        $body     = $request->get_body();
+        $expected = \hash_hmac('sha256', $timestamp.$body, $secret);
+
+        if (!\hash_equals($expected, $signature)) {
+            return new \WP_Error('invalid_signature', 'Invalid signature.', ['status' => 403]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Handle the invalidation request.
+     *
+     * @param \WP_REST_Request $request
+     * @return \WP_REST_Response
+     */
+    public function handle_request(\WP_REST_Request $request)
+    {
+        $params    = $request->get_json_params();
+        $flush_all = !empty($params['all']);
+        $files     = !empty($params['files']) && \is_array($params['files']) ? $params['files'] : [];
+
+        $invalidated = 0;
+
+        if ($flush_all) {
+            if (\function_exists('opcache_reset') && @opcache_reset()) {
+                $invalidated = -1; // signals "all"
+            }
+        } elseif (!empty($files)) {
+            foreach ($files as $file) {
+                $file = (string) $file;
+                // Only invalidate files inside the cache directory.
+                if (0 !== \strpos($file, nwdcx_normalizepath(DOCKET_CACHE_PATH))) {
+                    continue;
+                }
+                if (\function_exists('opcache_invalidate') && @opcache_invalidate($file, true)) {
+                    ++$invalidated;
+                }
+            }
+        }
+
+        return new \WP_REST_Response(
+            [
+                'success'     => true,
+                'invalidated' => $invalidated,
+            ],
+            200
+        );
+    }
+
+    /**
+     * Signal that a bulk flush is starting or ending.
+     * While true, per-file notifications in unlink() are suppressed.
+     *
+     * @param bool $state
+     * @return void
+     */
+    public static function set_bulk_flush(bool $state)
+    {
+        self::$bulk_flush = $state;
+    }
+
+    /**
+     * Whether a bulk flush is currently in progress.
+     *
+     * @return bool
+     */
+    public static function is_bulk_flush(): bool
+    {
+        return self::$bulk_flush;
+    }
+
+    /**
+     * Called from WP-CLI after cache files are flushed.
+     *
+     * Fires a non-blocking HTTP POST to the REST endpoint so that
+     * opcache_invalidate() / opcache_reset() runs in the web-server process.
+     *
+     * @param array $files  Absolute paths of cache files that were flushed.
+     *                      Pass an empty array to request a full opcache_reset().
+     * @return void
+     */
+    public static function notify(array $files = [])
+    {
+        if (!nwdcx_construe('WPCLI_OPCACHE')) {
+            return;
+        }
+
+        $secret = self::read_secret();
+        if (empty($secret)) {
+            return;
+        }
+
+        $flush_all = empty($files);
+        $body      = \wp_json_encode(
+            $flush_all
+                ? ['all' => true]
+                : ['files' => \array_values($files)]
+        );
+
+        if (false === $body) {
+            return;
+        }
+
+        $timestamp = (string) time();
+        $signature = \hash_hmac('sha256', $timestamp.$body, $secret);
+
+        $url = \get_rest_url(null, self::REST_NAMESPACE.self::REST_ROUTE);
+
+        \wp_remote_post(
+            $url,
+            [
+                'body'      => $body,
+                'headers'   => [
+                    'Content-Type'       => 'application/json',
+                    'X-Docket-Signature' => $signature,
+                    'X-Docket-Timestamp' => $timestamp,
+                ],
+                'timeout'   => 5,
+                'blocking'  => false,
+                'sslverify' => false,
+            ]
+        );
+    }
+
+    /**
+     * Get the shared secret, creating it if it does not exist.
+     *
+     * @return string
+     */
+    public function get_or_create_secret()
+    {
+        $secret = $this->pt->co()->lookup_get(self::SECRET_KEY);
+        if (!empty($secret) && \is_string($secret) && 64 === \strlen($secret)) {
+            return $secret;
+        }
+
+        // Generate a new 256-bit secret.
+        $secret = \bin2hex(\random_bytes(32));
+        $this->pt->co()->lookup_set(self::SECRET_KEY, $secret);
+
+        return $secret;
+    }
+
+    /**
+     * Read the shared secret from disk (CLI-safe, no WP object cache).
+     *
+     * Canopt stores lookup values as lock files in the data directory.
+     * We replicate the path logic here so CLI can read it without
+     * going through the object cache (which is the thing we're fixing).
+     *
+     * @return string
+     */
+    private static function read_secret()
+    {
+        // Canopt::lookup_get is available in CLI — use it directly.
+        $co = new Canopt();
+
+        return (string) $co->lookup_get(self::SECRET_KEY);
+    }
+}

--- a/includes/src/CliOpcache.php
+++ b/includes/src/CliOpcache.php
@@ -207,9 +207,11 @@ final class CliOpcache
 
         // Build the REST URL without get_rest_url() which requires $wp_rewrite
         // to be initialised (only available after the 'init' action). We use
-        // home_url() which is safe to call at any point after plugins_loaded.
+        // home_url() — the public-facing site root — which is safe to call at
+        // any point after plugins_loaded and correctly handles Bedrock's /wp/
+        // subdirectory install (siteurl includes /wp, home_url does not).
         $rest_prefix = \defined('REST_API_PREFIX') ? \REST_API_PREFIX : 'wp-json';
-        $url = \trailingslashit(\get_option('siteurl')).$rest_prefix.'/'.self::REST_NAMESPACE.self::REST_ROUTE;
+        $url = \trailingslashit(\get_option('home')).$rest_prefix.'/'.self::REST_NAMESPACE.self::REST_ROUTE;
 
         \wp_remote_post(
             $url,

--- a/includes/src/Constans.php
+++ b/includes/src/Constans.php
@@ -376,6 +376,15 @@ final class Constans
         // wp-cli
         $this->maybe_define($this->px('WPCLI'), \defined('WP_CLI') && WP_CLI);
 
+        // opcache invalidation via REST when running under WP-CLI.
+        // When opcache.validate_timestamps=0 (common on production), CLI-side
+        // opcache_invalidate() is a no-op because CLI and the web server have
+        // separate OPcache segments. Setting this to true (default) causes
+        // Docket Cache to fire a non-blocking HTTP request to the web server
+        // after any CLI flush so that opcache_invalidate/reset runs in the
+        // correct process. Set to false to disable.
+        $this->maybe_define($this->px('WPCLI_OPCACHE'), true);
+
         // banner
         $this->maybe_define($this->px('SIGNATURE'), true);
 

--- a/includes/src/Filesystem.php
+++ b/includes/src/Filesystem.php
@@ -473,13 +473,6 @@ class Filesystem
         // bcoz we empty the file
         $this->opcache_flush($file);
 
-        // When running under WP-CLI and not inside a bulk flush (which sends
-        // all:true after the loop), notify the web server to invalidate this
-        // specific file in its OPcache.
-        if (!CliOpcache::is_bulk_flush() && nwdcx_construe('WPCLI') && nwdcx_construe('WPCLI_OPCACHE') && $this->is_php($file)) {
-            CliOpcache::notify([$file]);
-        }
-
         $do_delete = (nwdcx_construe('FLUSH_DELETE') && $this->is_php($file)) || $is_delete;
 
         if ($do_delete && @unlink($file)) {
@@ -1028,10 +1021,6 @@ class Filesystem
 
         $this->suspend_cache_write(true);
 
-        // Suppress per-file CLI notifications during a full flush; we send
-        // a single all:true notification after the loop instead.
-        CliOpcache::set_bulk_flush(true);
-
         $gcisrun_lock = $dir.'/.gc-is-run.txt';
 
         $max_execution_time = $this->get_max_execution_time(180);
@@ -1083,8 +1072,6 @@ class Filesystem
 
         $this->suspend_cache_write(false);
         $is_done = true;
-
-        CliOpcache::set_bulk_flush(false);
 
         // When running under WP-CLI, opcache_invalidate() is a no-op because
         // CLI and the web server use separate OPcache segments. Notify the web

--- a/includes/src/Filesystem.php
+++ b/includes/src/Filesystem.php
@@ -473,6 +473,13 @@ class Filesystem
         // bcoz we empty the file
         $this->opcache_flush($file);
 
+        // When running under WP-CLI and not inside a bulk flush (which sends
+        // all:true after the loop), notify the web server to invalidate this
+        // specific file in its OPcache.
+        if (!CliOpcache::is_bulk_flush() && nwdcx_construe('WPCLI') && nwdcx_construe('WPCLI_OPCACHE') && $this->is_php($file)) {
+            CliOpcache::notify([$file]);
+        }
+
         $do_delete = (nwdcx_construe('FLUSH_DELETE') && $this->is_php($file)) || $is_delete;
 
         if ($do_delete && @unlink($file)) {
@@ -1021,6 +1028,10 @@ class Filesystem
 
         $this->suspend_cache_write(true);
 
+        // Suppress per-file CLI notifications during a full flush; we send
+        // a single all:true notification after the loop instead.
+        CliOpcache::set_bulk_flush(true);
+
         $gcisrun_lock = $dir.'/.gc-is-run.txt';
 
         $max_execution_time = $this->get_max_execution_time(180);
@@ -1072,6 +1083,15 @@ class Filesystem
 
         $this->suspend_cache_write(false);
         $is_done = true;
+
+        CliOpcache::set_bulk_flush(false);
+
+        // When running under WP-CLI, opcache_invalidate() is a no-op because
+        // CLI and the web server use separate OPcache segments. Notify the web
+        // server via REST so it can call opcache_reset() in the right process.
+        if (nwdcx_construe('WPCLI') && nwdcx_construe('WPCLI_OPCACHE')) {
+            CliOpcache::notify([]);
+        }
 
         return $cnt;
     }

--- a/includes/src/Plugin.php
+++ b/includes/src/Plugin.php
@@ -1508,6 +1508,17 @@ final class Plugin extends Bepart
     }
 
     /**
+     * register_cli_opcache.
+     *
+     * Registers the REST endpoint that allows WP-CLI to trigger OPcache
+     * invalidation inside the web-server process.
+     */
+    private function register_cli_opcache()
+    {
+        ( new CliOpcache($this) )->init();
+    }
+
+    /**
      * register_admin_hooks.
      */
     private function register_admin_hooks()
@@ -2379,6 +2390,7 @@ final class Plugin extends Bepart
         $this->register_admin_hooks();
         $this->register_tweaks();
         $this->register_cronjob();
+        $this->register_cli_opcache();
         $this->register_cli();
 
         nwdcx_runaction('docketcache/init', $this);

--- a/includes/src/Plugin.php
+++ b/includes/src/Plugin.php
@@ -1515,7 +1515,10 @@ final class Plugin extends Bepart
      */
     private function register_cli_opcache()
     {
-        ( new CliOpcache($this) )->init();
+        // Keep a reference on $this so the CliOpcache instance is not
+        // garbage-collected before rest_api_init fires.
+        $cli_opcache = new CliOpcache($this);
+        add_action('rest_api_init', [$cli_opcache, 'register_rest_route']);
     }
 
     /**

--- a/includes/vendor/composer/autoload_classmap.php
+++ b/includes/vendor/composer/autoload_classmap.php
@@ -9,6 +9,7 @@ return array(
     'Attribute' => $vendorDir . '/symfony/polyfill-php80/Resources/stubs/Attribute.php',
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
     'Nawawi\\DocketCache\\Becache' => $baseDir . '/includes/src/Becache.php',
+    'Nawawi\\DocketCache\\CliOpcache' => $baseDir . '/includes/src/CliOpcache.php',
     'Nawawi\\DocketCache\\Bepart' => $baseDir . '/includes/src/Bepart.php',
     'Nawawi\\DocketCache\\Canopt' => $baseDir . '/includes/src/Canopt.php',
     'Nawawi\\DocketCache\\Command' => $baseDir . '/includes/src/Command.php',


### PR DESCRIPTION
## Problem

When `opcache.validate_timestamps=0` (common on production for performance), flushing the Docket Cache from WP-CLI has no effect on the web server's in-memory OPcache. This is because:

1. `opcache.enable_cli=0` by default — CLI and the web server run in **separate processes with separate OPcache segments**
2. With `validate_timestamps=0` the web server never re-checks file mtimes, so truncated/deleted cache files continue to be served from bytecode cache indefinitely

**Practical impact**: operations like `wp plugin activate`, `wp cache flush`, or any CLI code that updates a cached value (e.g. `active_sitewide_plugins`) appear to have no effect until the OPcache TTL expires or the server restarts. This is a silent correctness bug.

## Solution

Introduce `CliOpcache` — a small bridge that fires a non-blocking HTTP POST from the CLI process to a REST endpoint registered by the plugin in the web-server process, where `opcache_invalidate()` / `opcache_reset()` actually work.

### Changes

**`includes/src/CliOpcache.php`** (new)
- Registers `POST /wp-json/docket-cache/v1/opcache-invalidate` via `rest_api_init`
- Verifies requests with HMAC-SHA256 using an auto-generated shared secret stored in the Docket Cache data directory (no user configuration required)
- Rejects requests older than 30 seconds (replay protection)
- Handles `{ "all": true }` → `opcache_reset()` and `{ "files": [...] }` → per-file `opcache_invalidate()`
- Provides `CliOpcache::notify(array $files)` static method called from CLI-side code
- Provides `set_bulk_flush(bool)` / `is_bulk_flush()` to suppress per-file notifications during a full flush (avoiding thousands of HTTP requests)

**`includes/src/Filesystem.php`**
- `cachedir_flush()`: after the flush loop, calls `CliOpcache::notify([])` (→ `opcache_reset()`) when running under WP-CLI
- `unlink()`: for individual deletes outside a bulk flush, calls `CliOpcache::notify([$file])` (→ `opcache_invalidate($file, true)`)

**`includes/src/Constans.php`**
- Adds `DOCKET_CACHE_WPCLI_OPCACHE` (default `true`) — set to `false` to opt out (e.g. when CLI and web server share a process, or `opcache.validate_timestamps=1` is already set)

**`includes/src/Plugin.php`**
- Calls `register_cli_opcache()` from `register()` to wire up the REST endpoint

**`includes/vendor/composer/autoload_classmap.php`**
- Adds `CliOpcache` to the classmap

### Security

- The shared secret is auto-generated (`random_bytes(32)`) on first use and stored in the Docket Cache data directory alongside other plugin data files
- All requests are authenticated with `hash_hmac('sha256', $timestamp . $body, $secret)`
- Timestamp window of 30 seconds prevents replay attacks
- File paths are validated to be within `DOCKET_CACHE_PATH` before invalidation

### Opt-out

```php
define('DOCKET_CACHE_WPCLI_OPCACHE', false);
```

This is appropriate when:
- Running PHP as `mod_php` (CLI and web server share OPcache)
- `opcache.validate_timestamps=1` is already set (file changes are detected automatically)
- The site has no REST API access from localhost